### PR TITLE
ci: enable manual build dispatch; next-only patch in seed-build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ on:
       - ".github/workflows/build.yml"
       - ".github/workflows/seed-build.yml"
       - "Makefile"
+  workflow_dispatch:
 
 jobs:
   pre-actions:
@@ -36,7 +37,7 @@ jobs:
     secrets: inherit
 
   build:
-    uses: daeuniverse/dae/.github/workflows/seed-build.yml@main
+    uses: ./.github/workflows/seed-build.yml
     with:
       ref: ${{ github.sha }}
       build-type: main-build

--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -71,6 +71,14 @@ jobs:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
 
+      - name: Apply upstream patch f6b4438
+        if: github.ref_name == 'next'
+        run: |
+          set -euo pipefail
+          echo "Applying patch from QiuSimons/dae commit f6b4438 on ${GITHUB_REF_NAME}"
+          curl -L -o /tmp/f6b4438.patch https://github.com/QiuSimons/dae/commit/f6b4438.patch
+          git apply -p1 /tmp/f6b4438.patch || echo "Patch not applicable; continuing"
+
       - name: Get the version
         id: get_version
         env:


### PR DESCRIPTION
- Add workflow_dispatch to build.yml so Actions supports manual run with branch selection.
- Switch build job to local reusable ./.github/workflows/seed-build.yml.
- Add conditional step to apply QiuSimons/dae commit f6b4438.patch only when building branch 'next' (non-fatal if not applicable).

This enables running the build manually for next and keeps main builds unaffected by the patch.